### PR TITLE
add Get it on F-Droid badge with link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 hosts for android,implement by vpn mode,supports wildcard DNS records
 
 <a href="https://play.google.com/store/apps/details?id=com.github.xfalcon.vhosts"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" height="48" /></a>
+<a href="https://f-droid.org/packages/com.github.xfalcon.vhosts"><img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" height="80"></a>
+
 
 Video Demo: <a target="_blank" href="https://www.youtube.com/watch?v=pHnsboAnm-A">https://www.youtube.com/watch?v=pHnsboAnm-A</a>
 


### PR DESCRIPTION
This MR adds the F-Droid badge with link pointing to [F-Droid store](https://f-droid.org/en/packages/com.github.xfalcon.vhosts/)

related issues: https://github.com/x-falcon/Virtual-Hosts/issues/47